### PR TITLE
Experimental tidying-up branch

### DIFF
--- a/src/GAuth/Auth.php
+++ b/src/GAuth/Auth.php
@@ -136,7 +136,7 @@ class Auth
      */
     public function setInitKey($key)
     {
-        if (preg_match('/^['.implode('', array_keys($this->getLookup())).']+$/', $key) == false) {
+        if (preg_match('/^['.implode('', array_keys($this->lookup)).']+$/', $key) == false) {
             throw new \InvalidArgumentException('Invalid base32 hash!');
         }
         $this->initKey = $key;
@@ -244,6 +244,7 @@ class Auth
         $timestamp = ($timestamp == null) ? $this->generateTimestamp() : $timestamp;
         $initKey = ($initKey == null) ? $this->getInitKey() : $initKey;
 
+
         $binary = $this->base32_decode($initKey);
 
         for ($time = ($timestamp - $range); $time <= ($timestamp + $range); $time++) {
@@ -285,7 +286,7 @@ class Auth
      */
     public function generateCode($length = 16)
     {
-        $lookup = implode('', array_keys($this->getLookup()));
+        $lookup = implode('', array_keys($this->lookup));
         $code = '';
 
         for ($i = 0; $i < $length; $i++) {
@@ -332,7 +333,7 @@ class Auth
      */
     public function base32_decode($hash)
     {
-        $lookup = $this->getLookup();
+        $lookup = $this->lookup;
 
         if (preg_match('/^['.implode('', array_keys($lookup)).']+$/', $hash) == false) {
             throw new \InvalidArgumentException('Invalid base32 hash!');

--- a/src/GAuth/Auth.php
+++ b/src/GAuth/Auth.php
@@ -20,7 +20,40 @@ class Auth
      * Internal lookup table
      * @var array
      */
-    private $lookup = array();
+    private $lookup = array(
+        'A' => 0,
+        'B' => 1,
+        'C' => 2,
+        'D' => 3,
+        'E' => 4,
+        'F' => 5,
+        'G' => 6,
+        'H' => 7,
+        'I' => 8,
+        'J' => 9,
+        'K' => 10,
+        'L' => 11,
+        'M' => 12,
+        'N' => 13,
+        'O' => 14,
+        'P' => 15,
+        'Q' => 16,
+        'R' => 17,
+        'S' => 18,
+        'T' => 19,
+        'U' => 20,
+        'V' => 21,
+        'W' => 22,
+        'X' => 23,
+        'Y' => 24,
+        'Z' => 25,
+        2 => 26,
+        3 => 27,
+        4 => 28,
+        5 => 29,
+        6 => 30,
+        7 => 31,
+    );
 
     /**
      * Initialization key
@@ -54,8 +87,6 @@ class Auth
      */
     public function __construct($initKey = null)
     {
-        $this->buildLookup();
-
         if ($initKey !== null) {
             $this->setInitKey($initKey);
         }
@@ -64,15 +95,12 @@ class Auth
     /**
      * Build the base32 lookup table
      *
+     * @deprecated Hard-coded in.
      * @return null
      */
     public function buildLookup()
     {
-        $lookup = array_combine(
-            array_merge(range('A', 'Z'), range(2, 7)),
-            range(0, 31)
-        );
-        $this->setLookup($lookup);
+        trigger_error('The base32 lookup table now comes pre-built.', E_USER_DEPRECATED);
     }
 
     /**
@@ -134,11 +162,7 @@ class Auth
      */
     public function setLookup($lookup)
     {
-        if (!is_array($lookup)) {
-            throw new \InvalidArgumentException('Lookup value must be an array');
-        }
-        $this->lookup = $lookup;
-        return $this;
+        trigger_error('The base 32 lookup should not ever be overwritten.', E_USER_DEPRECATED);
     }
 
     /**
@@ -148,6 +172,7 @@ class Auth
      */
     public function getLookup()
     {
+        trigger_error('This method will be removed in a later version', E_USER_DEPRECATED);
         return $this->lookup;
     }
 

--- a/src/GAuth/Auth.php
+++ b/src/GAuth/Auth.php
@@ -171,7 +171,7 @@ class Auth
     public function setRefresh($seconds)
     {
         if (!is_numeric($seconds)) {
-            throw \InvalidArgumentException('Seconds must be numeric');
+            throw new \InvalidArgumentException('Seconds must be numeric');
         }
         $this->refreshSeconds = $seconds;
         return $this;

--- a/src/GAuth/Auth.php
+++ b/src/GAuth/Auth.php
@@ -240,9 +240,19 @@ class Auth
             throw new \InvalidArgumentException('Incorrect code length');
         }
 
-        $range = ($range == null) ? $this->getRange() : $range;
-        $timestamp = ($timestamp == null) ? $this->generateTimestamp() : $timestamp;
-        $initKey = ($initKey == null) ? $this->getInitKey() : $initKey;
+        if ($initKey) {
+            $this->setInitKey($initKey);
+        }
+        $initKey = $this->getInitKey();
+        
+        if ($timestamp === null) {
+            $timestamp = $this->generateTimestamp();
+        }
+
+        if ($range) {
+            $this->setRange($range);
+        }
+        $range = $this->getRange();
 
 
         $binary = $this->base32_decode($initKey);

--- a/src/GAuth/Auth.php
+++ b/src/GAuth/Auth.php
@@ -272,7 +272,7 @@ class Auth
      * @param string $timestamp Timestamp for calculation [optional]
      * @return string Geneerated code/hash
      */
-    public function generateOneTime($initKey = null, $timestamp = null)
+    private function generateOneTime($initKey = null, $timestamp = null)
     {
         $initKey = ($initKey == null) ? $this->getInitKey() : $initKey;
         $timestamp = ($timestamp == null) ? $this->generateTimestamp() : $timestamp;
@@ -311,7 +311,7 @@ class Auth
      *
      * @return integer Timestamp
      */
-    public function generateTimestamp()
+    private function generateTimestamp()
     {
         return floor(microtime(true)/$this->getRefresh());
     }
@@ -322,7 +322,7 @@ class Auth
      * @param string $hash Hash to truncate
      * @return string Truncated hash value
      */
-    public function truncateHash($hash)
+    private function truncateHash($hash)
     {
         $offset = ord($hash[19]) & 0xf;
 
@@ -341,7 +341,7 @@ class Auth
      * @throws \InvalidArgumentException When hash is not valid
      * @return string Binary value of hash
      */
-    public function base32_decode($hash)
+    private function base32_decode($hash)
     {
         $lookup = $this->lookup;
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,3 @@
+<?php
+
+require_once dirname(__DIR__) . '/src/GAuth/Auth.php';

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -1,0 +1,7 @@
+<phpunit bootstrap="./bootstrap.php">
+	<testsuites>
+		<testsuite>
+			<directory>./src</directory>
+		</testsuite>
+	</testsuites>
+</phpunit>

--- a/tests/src/AuthTest.php
+++ b/tests/src/AuthTest.php
@@ -24,14 +24,7 @@ class AuthTest extends \PHPUnit_Framework_TestCase {
     }
 
 
-    public function test_base64_lookup_is_correct () {
-
-        $expected = $this->base64values;
-
-        $auth = new Auth();
-        $this->assertEquals($expected, $auth->getLookup());
-    }
-
+    
 
     public function test_get_and_set_range () {
 

--- a/tests/src/AuthTest.php
+++ b/tests/src/AuthTest.php
@@ -93,6 +93,75 @@ class AuthTest extends \PHPUnit_Framework_TestCase {
 	}
 
 
+	public function test_generate_a_code_of_length () {
+		$auth = new Auth();
+		$code = $auth->generateCode(4);
+		$this->assertEquals(4, strlen($code), 'Default code is 16 chars');
+	}
+
+
+	public function test_validate_a_valid_code () {
+
+		$key = 'ABC';
+		$auth = new Auth($key);
+		$code = '424535';
+		$timestamp = 1421707340;
+
+		$result = $auth->validateCode($code, null, $timestamp);
+		$this->assertTrue($result, 'This is a known good code');
+
+	}
+
+
+	public function test_validate_a_valid_code_false_when_out_of_range () {
+
+		$key = 'ABC';
+		$code = '424535';
+		$timestamp = 1421707340;
+
+		$auth = new Auth($key);
+		$auth->setRange(1);
+
+		$result = $auth->validateCode($code, null, $timestamp);
+		$this->assertFalse($result, 'This was a known good code 2 seconds ago');		
+	}
+
+
+	public function test_validate_a_code_of_wrong_length_fails () {
+
+		$this->setExpectedException('InvalidArgumentException');
+
+		$auth = new Auth();
+		$auth->setCodeLength(10);
+		$auth->validateCode('lt10');
+	
+	}
+
+
+	public function test_validate_with_different_init_key_is_false () {
+
+		$key = 'DEF';
+		$auth = new Auth($key);
+		$code = '424535';
+		$timestamp = 1421707340;
+
+		$result = $auth->validateCode($code, null, $timestamp);
+		$this->assertFalse($result, 'This is a known good code for key ABC');
+
+	}
+
+
+	public function test_validate_after_time_has_passed_is_false () {
+
+		$key = 'ABC';
+		$auth = new Auth($key);
+		$code = '424535';
+
+		$result = $auth->validateCode($code);
+		$this->assertFalse($result, 'This was a known good code, but that was then');
+	}
+
+
 	private $base64values = array(
         'A' => 0,
         'B' => 1,

--- a/tests/src/AuthTest.php
+++ b/tests/src/AuthTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace GAuth;
+
+class AuthTest extends \PHPUnit_Framework_TestCase {
+
+
+	public function test_instantiate () {
+		$auth = new Auth();
+	}
+
+	public function test_invalid_init_key_fails () {
+
+		$this->setExpectedException("InvalidArgumentException", "Invalid base32 hash!");
+		new Auth('~');
+	}
+
+	public function test_valid_init_key_gets_set () {
+		$key = 'ABC';
+		$auth = new Auth($key);
+		$this->assertEquals($key, $auth->getInitKey(), 'Key can be got');
+	}
+
+}

--- a/tests/src/AuthTest.php
+++ b/tests/src/AuthTest.php
@@ -9,16 +9,96 @@ class AuthTest extends \PHPUnit_Framework_TestCase {
 		$auth = new Auth();
 	}
 
+
 	public function test_invalid_init_key_fails () {
 
 		$this->setExpectedException("InvalidArgumentException", "Invalid base32 hash!");
 		new Auth('~');
 	}
 
+
 	public function test_valid_init_key_gets_set () {
 		$key = 'ABC';
 		$auth = new Auth($key);
-		$this->assertEquals($key, $auth->getInitKey(), 'Key can be got');
+		$this->assertEquals($key, $auth->getInitKey(), 'Valid key can be got');
 	}
 
+
+	public function test_base64_lookup_is_correct () {
+
+		$expected = array(
+            'A' => 0,
+            'B' => 1,
+            'C' => 2,
+            'D' => 3,
+            'E' => 4,
+		    'F' => 5,
+		    'G' => 6,
+		    'H' => 7,
+		    'I' => 8,
+		    'J' => 9,
+		    'K' => 10,
+		    'L' => 11,
+		    'M' => 12,
+		    'N' => 13,
+		    'O' => 14,
+		    'P' => 15,
+		    'Q' => 16,
+		    'R' => 17,
+		    'S' => 18,
+		    'T' => 19,
+		    'U' => 20,
+		    'V' => 21,
+		    'W' => 22,
+		    'X' => 23,
+		    'Y' => 24,
+		    'Z' => 25,
+		    2 => 26,
+		    3 => 27,
+		    4 => 28,
+		    5 => 29,
+		    6 => 30,
+		    7 => 31,
+        );
+        $auth = new Auth();
+        $this->assertEquals($expected, $auth->getLookup());
+	}
+
+
+	public function test_get_and_set_range () {
+
+		$range = 54;
+		$auth = new Auth();
+		$auth->setRange($range);
+		$this->assertEquals($range, $auth->getRange(), 'Range is set correctly');
+	}
+
+	public function test_invalid_range_fails () {
+
+		$this->setExpectedException('InvalidArgumentException');
+		$auth = new Auth();
+		$auth->setRange("cat");
+	
+	}
+
+
+	public function test_set_and_get_refresh () {
+
+		$refresh = 43;
+		$auth = new Auth();
+		$auth->setRefresh($refresh);
+		$this->assertEquals($refresh, $auth->getRefresh(), 'Refresh is set and got OK');
+	
+	}
+
+
+	public function test_invalid_refresh_fails () {
+
+		$this->setExpectedException('InvalidArgumentException');
+		$auth = new Auth();
+		$auth->setRefresh("litter");
+
+	}
+
+	
 }

--- a/tests/src/AuthTest.php
+++ b/tests/src/AuthTest.php
@@ -5,195 +5,195 @@ namespace GAuth;
 class AuthTest extends \PHPUnit_Framework_TestCase {
 
 
-	public function test_instantiate () {
-		$auth = new Auth();
-	}
+    public function test_instantiate () {
+        $auth = new Auth();
+    }
 
 
-	public function test_invalid_init_key_fails () {
+    public function test_invalid_init_key_fails () {
 
-		$this->setExpectedException("InvalidArgumentException", "Invalid base32 hash!");
-		new Auth('~');
-	}
-
-
-	public function test_valid_init_key_gets_set () {
-		$key = 'ABC';
-		$auth = new Auth($key);
-		$this->assertEquals($key, $auth->getInitKey(), 'Valid key can be got');
-	}
+        $this->setExpectedException("InvalidArgumentException", "Invalid base32 hash!");
+        new Auth('~');
+    }
 
 
-	public function test_base64_lookup_is_correct () {
+    public function test_valid_init_key_gets_set () {
+        $key = 'ABC';
+        $auth = new Auth($key);
+        $this->assertEquals($key, $auth->getInitKey(), 'Valid key can be got');
+    }
 
-		$expected = $this->base64values;
+
+    public function test_base64_lookup_is_correct () {
+
+        $expected = $this->base64values;
 
         $auth = new Auth();
         $this->assertEquals($expected, $auth->getLookup());
-	}
+    }
 
 
-	public function test_get_and_set_range () {
+    public function test_get_and_set_range () {
 
-		$range = 54;
-		$auth = new Auth();
-		$auth->setRange($range);
-		$this->assertEquals($range, $auth->getRange(), 'Range is set correctly');
-	}
+        $range = 54;
+        $auth = new Auth();
+        $auth->setRange($range);
+        $this->assertEquals($range, $auth->getRange(), 'Range is set correctly');
+    }
 
-	public function test_invalid_range_fails () {
+    public function test_invalid_range_fails () {
 
-		$this->setExpectedException('InvalidArgumentException');
-		$auth = new Auth();
-		$auth->setRange("cat");
-	
-	}
-
-
-	public function test_set_and_get_refresh () {
-
-		$refresh = 43;
-		$auth = new Auth();
-		$auth->setRefresh($refresh);
-		$this->assertEquals($refresh, $auth->getRefresh(), 'Refresh is set and got OK');
-	
-	}
+        $this->setExpectedException('InvalidArgumentException');
+        $auth = new Auth();
+        $auth->setRange("cat");
+    
+    }
 
 
-	public function test_invalid_refresh_fails () {
+    public function test_set_and_get_refresh () {
 
-		$this->setExpectedException('InvalidArgumentException');
-		$auth = new Auth();
-		$auth->setRefresh("litter");
-
-	}
-
-
-	public function test_set_and_get_code_length () {
-
-		$length = 123;
-		$auth = new Auth();
-		$auth->setCodeLength($length);
-		$this->assertEquals($length, $auth->getCodeLength());
-	}
+        $refresh = 43;
+        $auth = new Auth();
+        $auth->setRefresh($refresh);
+        $this->assertEquals($refresh, $auth->getRefresh(), 'Refresh is set and got OK');
+    
+    }
 
 
-	public function test_generate_a_init_code () {
+    public function test_invalid_refresh_fails () {
 
-		$auth = new Auth();
-		$code = $auth->generateCode();
-		$this->assertEquals(16, strlen($code), 'Default code is 16 chars');
+        $this->setExpectedException('InvalidArgumentException');
+        $auth = new Auth();
+        $auth->setRefresh("litter");
 
-		$base64values = array_keys($this->base64values);
-		$code_letters = str_split($code);
-
-		foreach ($code_letters as $letter) {
-			$this->assertContains($letter, $base64values, 'Key consists of base 64 values');
-		}
-	}
+    }
 
 
-	public function test_generate_a_code_of_length () {
-		$auth = new Auth();
-		$code = $auth->generateCode(4);
-		$this->assertEquals(4, strlen($code), 'Default code is 16 chars');
-	}
+    public function test_set_and_get_code_length () {
+
+        $length = 123;
+        $auth = new Auth();
+        $auth->setCodeLength($length);
+        $this->assertEquals($length, $auth->getCodeLength());
+    }
 
 
-	public function test_validate_a_valid_code () {
+    public function test_generate_a_init_code () {
 
-		$key = 'ABC';
-		$auth = new Auth($key);
-		$code = '424535';
-		$timestamp = 1421707340;
+        $auth = new Auth();
+        $code = $auth->generateCode();
+        $this->assertEquals(16, strlen($code), 'Default code is 16 chars');
 
-		$result = $auth->validateCode($code, null, $timestamp);
-		$this->assertTrue($result, 'This is a known good code');
+        $base64values = array_keys($this->base64values);
+        $code_letters = str_split($code);
 
-	}
-
-
-	public function test_validate_a_valid_code_false_when_out_of_range () {
-
-		$key = 'ABC';
-		$code = '424535';
-		$timestamp = 1421707340;
-
-		$auth = new Auth($key);
-		$auth->setRange(1);
-
-		$result = $auth->validateCode($code, null, $timestamp);
-		$this->assertFalse($result, 'This was a known good code 2 seconds ago');		
-	}
+        foreach ($code_letters as $letter) {
+            $this->assertContains($letter, $base64values, 'Key consists of base 64 values');
+        }
+    }
 
 
-	public function test_validate_a_code_of_wrong_length_fails () {
-
-		$this->setExpectedException('InvalidArgumentException');
-
-		$auth = new Auth();
-		$auth->setCodeLength(10);
-		$auth->validateCode('lt10');
-	
-	}
+    public function test_generate_a_code_of_length () {
+        $auth = new Auth();
+        $code = $auth->generateCode(4);
+        $this->assertEquals(4, strlen($code), 'Default code is 16 chars');
+    }
 
 
-	public function test_validate_with_different_init_key_is_false () {
+    public function test_validate_a_valid_code () {
 
-		$key = 'DEF';
-		$auth = new Auth($key);
-		$code = '424535';
-		$timestamp = 1421707340;
+        $key = 'ABC';
+        $auth = new Auth($key);
+        $code = '424535';
+        $timestamp = 1421707340;
 
-		$result = $auth->validateCode($code, null, $timestamp);
-		$this->assertFalse($result, 'This is a known good code for key ABC');
+        $result = $auth->validateCode($code, null, $timestamp);
+        $this->assertTrue($result, 'This is a known good code');
 
-	}
-
-
-	public function test_validate_after_time_has_passed_is_false () {
-
-		$key = 'ABC';
-		$auth = new Auth($key);
-		$code = '424535';
-
-		$result = $auth->validateCode($code);
-		$this->assertFalse($result, 'This was a known good code, but that was then');
-	}
+    }
 
 
-	private $base64values = array(
+    public function test_validate_a_valid_code_false_when_out_of_range () {
+
+        $key = 'ABC';
+        $code = '424535';
+        $timestamp = 1421707340;
+
+        $auth = new Auth($key);
+        $auth->setRange(1);
+
+        $result = $auth->validateCode($code, null, $timestamp);
+        $this->assertFalse($result, 'This was a known good code 2 seconds ago');        
+    }
+
+
+    public function test_validate_a_code_of_wrong_length_fails () {
+
+        $this->setExpectedException('InvalidArgumentException');
+
+        $auth = new Auth();
+        $auth->setCodeLength(10);
+        $auth->validateCode('lt10');
+    
+    }
+
+
+    public function test_validate_with_different_init_key_is_false () {
+
+        $key = 'DEF';
+        $auth = new Auth($key);
+        $code = '424535';
+        $timestamp = 1421707340;
+
+        $result = $auth->validateCode($code, null, $timestamp);
+        $this->assertFalse($result, 'This is a known good code for key ABC');
+
+    }
+
+
+    public function test_validate_after_time_has_passed_is_false () {
+
+        $key = 'ABC';
+        $auth = new Auth($key);
+        $code = '424535';
+
+        $result = $auth->validateCode($code);
+        $this->assertFalse($result, 'This was a known good code, but that was then');
+    }
+
+
+    private $base64values = array(
         'A' => 0,
         'B' => 1,
         'C' => 2,
         'D' => 3,
         'E' => 4,
-	    'F' => 5,
-	    'G' => 6,
-	    'H' => 7,
-	    'I' => 8,
-	    'J' => 9,
-	    'K' => 10,
-	    'L' => 11,
-	    'M' => 12,
-	    'N' => 13,
-	    'O' => 14,
-	    'P' => 15,
-	    'Q' => 16,
-	    'R' => 17,
-	    'S' => 18,
-	    'T' => 19,
-	    'U' => 20,
-	    'V' => 21,
-	    'W' => 22,
-	    'X' => 23,
-	    'Y' => 24,
-	    'Z' => 25,
-	    2 => 26,
-	    3 => 27,
-	    4 => 28,
-	    5 => 29,
-	    6 => 30,
-	    7 => 31,
+        'F' => 5,
+        'G' => 6,
+        'H' => 7,
+        'I' => 8,
+        'J' => 9,
+        'K' => 10,
+        'L' => 11,
+        'M' => 12,
+        'N' => 13,
+        'O' => 14,
+        'P' => 15,
+        'Q' => 16,
+        'R' => 17,
+        'S' => 18,
+        'T' => 19,
+        'U' => 20,
+        'V' => 21,
+        'W' => 22,
+        'X' => 23,
+        'Y' => 24,
+        'Z' => 25,
+        2 => 26,
+        3 => 27,
+        4 => 28,
+        5 => 29,
+        6 => 30,
+        7 => 31,
     );
 }

--- a/tests/src/AuthTest.php
+++ b/tests/src/AuthTest.php
@@ -26,40 +26,8 @@ class AuthTest extends \PHPUnit_Framework_TestCase {
 
 	public function test_base64_lookup_is_correct () {
 
-		$expected = array(
-            'A' => 0,
-            'B' => 1,
-            'C' => 2,
-            'D' => 3,
-            'E' => 4,
-		    'F' => 5,
-		    'G' => 6,
-		    'H' => 7,
-		    'I' => 8,
-		    'J' => 9,
-		    'K' => 10,
-		    'L' => 11,
-		    'M' => 12,
-		    'N' => 13,
-		    'O' => 14,
-		    'P' => 15,
-		    'Q' => 16,
-		    'R' => 17,
-		    'S' => 18,
-		    'T' => 19,
-		    'U' => 20,
-		    'V' => 21,
-		    'W' => 22,
-		    'X' => 23,
-		    'Y' => 24,
-		    'Z' => 25,
-		    2 => 26,
-		    3 => 27,
-		    4 => 28,
-		    5 => 29,
-		    6 => 30,
-		    7 => 31,
-        );
+		$expected = $this->base64values;
+
         $auth = new Auth();
         $this->assertEquals($expected, $auth->getLookup());
 	}
@@ -100,5 +68,63 @@ class AuthTest extends \PHPUnit_Framework_TestCase {
 
 	}
 
-	
+
+	public function test_set_and_get_code_length () {
+
+		$length = 123;
+		$auth = new Auth();
+		$auth->setCodeLength($length);
+		$this->assertEquals($length, $auth->getCodeLength());
+	}
+
+
+	public function test_generate_a_init_code () {
+
+		$auth = new Auth();
+		$code = $auth->generateCode();
+		$this->assertEquals(16, strlen($code), 'Default code is 16 chars');
+
+		$base64values = array_keys($this->base64values);
+		$code_letters = str_split($code);
+
+		foreach ($code_letters as $letter) {
+			$this->assertContains($letter, $base64values, 'Key consists of base 64 values');
+		}
+	}
+
+
+	private $base64values = array(
+        'A' => 0,
+        'B' => 1,
+        'C' => 2,
+        'D' => 3,
+        'E' => 4,
+	    'F' => 5,
+	    'G' => 6,
+	    'H' => 7,
+	    'I' => 8,
+	    'J' => 9,
+	    'K' => 10,
+	    'L' => 11,
+	    'M' => 12,
+	    'N' => 13,
+	    'O' => 14,
+	    'P' => 15,
+	    'Q' => 16,
+	    'R' => 17,
+	    'S' => 18,
+	    'T' => 19,
+	    'U' => 20,
+	    'V' => 21,
+	    'W' => 22,
+	    'X' => 23,
+	    'Y' => 24,
+	    'Z' => 25,
+	    2 => 26,
+	    3 => 27,
+	    4 => 28,
+	    5 => 29,
+	    6 => 30,
+	    7 => 31,
+    );
 }


### PR DESCRIPTION
I'm not really expecting you to accept this, which is completely fine.  GAuth is obviously on packagist with people using it (myself gratefully included) who might not appreciate breaking API changes.  It's more for discussion.

First of all, I don't understand when the base32 lookup table would ever change, or be changed.  So, apart from saving some space, I'm not sure why you'd want to build it on construction, and why you have public getters and settings on it.  So I've put it in hard-coded, and put some deprecation errors on the related methods.

Secondly, calling validateCode with the 2nd, 3rd and 4th optional params doesn't set them on the instance, which also means they are not validated.  There's a change here to `set` and then `get` if they are passed, which is what I'd expect them to do.  In fact, I'd remove the `$initKey` and `$range` parameters completely.  Alternatively, the validation could be extracted into separate methods and called there, or a Value Object for the params used (which might be over-engineering, and is a very big API change).

Lastly, I've changed the visibility on some of the helper methods because I don't understand when you'd ever call those methods from the outside.

Apologies if my misunderstandings have led to any of these comments/changes.  They are meant to be constructive.  Also, do please let me know if you'd like any help with other aspects of this - for example, would a more detailed 'how to implement 2FA using this' document be useful?
